### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/templates/CRM/Enhancedjobmanager/Page/Job.tpl
+++ b/templates/CRM/Enhancedjobmanager/Page/Job.tpl
@@ -154,7 +154,7 @@
                 <svg class="search-icon icon" viewBox="0 0 24 24">
                   <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
                 </svg>
-                <input type="text" placeholder="{ts}Search jobs...{/ts}" class="filter-input" id="searchInput">
+                <input type="text" placeholder="{ts escape='htmlattribute'}Search jobs...{/ts}" class="filter-input" id="searchInput">
               </div>
               <a href="{$runAllURL}" class="crm-modern-button crm-modern-button-secondary">
                 <i class="crm-i fa-play" aria-hidden="true"></i>
@@ -261,7 +261,7 @@
                     </td>
                     <td class="crm-job-success-rate">
                       {if $row.success_rate !== null}
-                        <div class="tooltip" data-tooltip="{ts 1=$row.success_rate}%1% success rate over last 30 days{/ts}">
+                        <div class="tooltip" data-tooltip="{ts escape='htmlattribute' 1=$row.success_rate}%1% success rate over last 30 days{/ts}">
                             <span style="color: {if $row.success_rate >= 95}#10b981{elseif $row.success_rate >= 85}#f59e0b{else}#ef4444{/if}; font-weight: 600;">
                               {$row.success_rate}%
                             </span>

--- a/templates/CRM/Enhancedjobmanager/Page/JobStats.tpl
+++ b/templates/CRM/Enhancedjobmanager/Page/JobStats.tpl
@@ -205,7 +205,7 @@
               <td>
                 <div class="crm-submit-buttons">
                   <a href="{crmURL p='civicrm/admin/job' q="action=update&id=`$job.id`&reset=1"}"
-                     class="crm-button crm-button-small" title="{ts}Edit Job{/ts}">
+                     class="crm-button crm-button-small" title="{ts escape='htmlattribute'}Edit Job{/ts}">
                     <i class="crm-i fa-edit"></i>
                   </a>
                 </div>
@@ -514,7 +514,7 @@
                   nextRun,
                   job.execution_count || 0,
                   '<span class="error-rate ' + (job.error_rate > 10 ? 'high-error' : job.error_rate > 5 ? 'medium-error' : 'low-error') + '">' + job.error_rate + '%</span>',
-                  '<div class="crm-submit-buttons"><a href="'+ CRM.url('civicrm/admin/job', {action: 'update', id: job.id, reset: 1}) + '"class="crm-button crm-button-small" title="{ts}Edit Job{/ts}"> <i class="crm-i fa-edit"></i></a> </div>'
+                  '<div class="crm-submit-buttons"><a href="'+ CRM.url('civicrm/admin/job', {action: 'update', id: job.id, reset: 1}) + '"class="crm-button crm-button-small" title="{ts escape='htmlattribute'}Edit Job{/ts}"> <i class="crm-i fa-edit"></i></a> </div>'
                 ]);
               });
             }


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.